### PR TITLE
Fixed: Assembly generation for DLLs without .reloc [Platform: x64]

### DIFF
--- a/ILRepack/Steps/Win32Resources/PE/ImageWriter.cs
+++ b/ILRepack/Steps/Win32Resources/PE/ImageWriter.cs
@@ -136,7 +136,9 @@ namespace ILRepacking.Steps.Win32Resources.PE
             WriteSectionHeaders();
             CopySection(_origText, _text);
             WriteSection(_rsrc, _win32Resources);
-            CopySection(_origReloc, _reloc);
+            
+            if (_origReloc != null && _reloc != null)
+                CopySection(_origReloc, _reloc);
         }
 
         private void CopyBytes(int bytes)


### PR DESCRIPTION
Skips copying of the `.reloc` section if not present. This section is not emitted to PE files specifically targeting x64.

i.e. Those built with `dotnet build /p:Platform=x64`.

This issue was originally introduced in b9b8f9f852678d8dfeea745f98b6f18fa7cef936 .
This issue currently affects all currently NuGet published, including `ILRepack.Lib.MSBuild.Task`, a package update is suggested if possible.

-------------

x64 DLL:

![image](https://user-images.githubusercontent.com/6697380/182050064-e6443714-2a8c-4f68-b3aa-faa6bbcdbd47.png)

x86, AnyCPU DLL:

![image](https://user-images.githubusercontent.com/6697380/182050075-128359ac-354e-4002-9786-e7b11282c456.png)
